### PR TITLE
最終ログイン時間が24時間以内 & 更新時間が10分以内のプレイヤーを取得

### DIFF
--- a/server/app/api/web/player.py
+++ b/server/app/api/web/player.py
@@ -1,6 +1,6 @@
 
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from flask import Blueprint, g, request, jsonify
 from app.models import Player
 
@@ -13,4 +13,17 @@ def get_player_all():
     player_count = len(players)
     response = []
     data = {"players" : player_count}
+    return jsonify(data)
+
+@app.route("/api/web/players/loginStatus", methods=['GET'])
+def get_players_login_all():
+    day = datetime.now() - timedelta(days = 1)
+    times = datetime.now() - timedelta(seconds = 600)
+    players_login_days = g.session.query(Player).filter(
+        Player.last_login_at > day,
+        Player.updated_at > times
+    ).count()
+    data = {
+        "now": players_login_days
+    }
     return jsonify(data)


### PR DESCRIPTION
現在のログイン人数を取得するAPIをつくる@ホームページ用 #31